### PR TITLE
change CDN for samples

### DIFF
--- a/sample/demo.html
+++ b/sample/demo.html
@@ -111,8 +111,8 @@
     <script type="importmap">
         {
             "imports": {
-                "vue": "https://unpkg.com/vue/dist/vue.esm-browser.js",
-                "text-ellipsis2": "https://unpkg.com/text-ellipsis2/es/index.js"
+                "vue": "https://cdn.jsdelivr.net/npm/vue/dist/vue.esm-browser.js",
+                "text-ellipsis2": "https://cdn.jsdelivr.net/npm/text-ellipsis2/es/index.js"
             }
         }
     </script>

--- a/sample/stress.html
+++ b/sample/stress.html
@@ -43,8 +43,8 @@
     <script type="importmap">
         {
             "imports": {
-                "vue": "https://unpkg.com/vue/dist/vue.esm-browser.js",
-                "text-ellipsis2": "https://unpkg.com/text-ellipsis2/es/index.js"
+                "vue": "https://cdn.jsdelivr.net/npm/vue/dist/vue.esm-browser.js",
+                "text-ellipsis2": "https://cdn.jsdelivr.net/npm/text-ellipsis2/es/index.js"
             }
         }
     </script>


### PR DESCRIPTION
unpkg returns 520 errors for vue and text-ellipsis. This does not seem like a new error, see https://github.com/mjackson/unpkg/issues/343 and one comment suggested using jsdelivr.